### PR TITLE
Add bootstrap install script, shell configs, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,30 @@
 # Termstack
 
-**Termstack** is my personal toolkit for building a fast, consistent, Linux CLI environment.  
-It’s a collection of scripts, configs, and small utilities to bootstrap my preferred terminal setup on any machine.
-
----
+Termstack bootstraps a customized Linux command-line environment. It installs a curated set of tools, provides Zsh and Fish configurations, and sets up the [Starship](https://starship.rs) prompt.
 
 ## Features
 
-- 🛠 Automated environment setup
-- ⚡ Optimized shell configurations
-- 📦 Installs my go-to CLI tools
-- 🎨 Custom prompt, aliases, and keybindings
-- 🔄 Repeatable and portable across systems
+- 🛠 Automated package installation and symlink replacement for modern CLI tools
+- ⚡ Zsh or Fish shell configuration with plugin managers (`zinit` and `fisher`)
+- 🎨 Optional Starship prompt with shared configuration
+- 🔧 Tmux config, handy aliases, and smart defaults
+- 📚 Documentation and cheat sheets for quick reference
 
----
+## Installation
 
-## Getting Started
-
-Clone the repo:
+Clone the repo and run the installer:
 
 ```bash
 git clone https://github.com/azcoigreach/termstack.git
 cd termstack
+./install.sh
+```
+
+During installation you'll be prompted to choose which shell to install and whether to enable the Starship prompt.
+
+## Documentation
+
+- [`docs/command_reference.md`](docs/command_reference.md) – list of installed tools and links
+- [`docs/cheatsheet.md`](docs/cheatsheet.md) – common commands and tips
+
+Configuration files are located under `config/`. Symlinks to replace classic tools are installed to `$HOME/bin`; ensure it's on your `$PATH`.

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -1,0 +1,15 @@
+if status is-interactive
+    # Initialize tools
+    if type -q zoxide
+        zoxide init fish | source
+    end
+    if type -q starship
+        starship init fish | source
+    end
+
+    # Aliases
+    alias ls "exa --icons"
+    alias cat "bat"
+    alias grep "rg"
+    alias find "fd"
+end

--- a/config/starship.toml
+++ b/config/starship.toml
@@ -1,0 +1,9 @@
+add_newline = false
+
+[character]
+success_symbol = "[✔](bold green) "
+error_symbol = "[✘](bold red) "
+
+[cmd_duration]
+min_time = 500
+format = "took [$duration]($style) "

--- a/config/tmux.conf
+++ b/config/tmux.conf
@@ -1,0 +1,4 @@
+set -g mouse on
+setw -g mode-keys vi
+set -g history-limit 5000
+bind r source-file ~/.tmux.conf \; display-message "Reloaded!"

--- a/config/zsh/.zshrc
+++ b/config/zsh/.zshrc
@@ -1,0 +1,25 @@
+# Load zinit if available, otherwise install it
+if [ ! -f ${ZDOTDIR:-$HOME}/.zinit/bin/zinit.zsh ]; then
+  mkdir -p ${ZDOTDIR:-$HOME}/.zinit
+  git clone https://github.com/zdharma-continuum/zinit.git ${ZDOTDIR:-$HOME}/.zinit/bin
+fi
+source ${ZDOTDIR:-$HOME}/.zinit/bin/zinit.zsh
+
+# Plugins
+zinit light zdharma-continuum/fast-syntax-highlighting
+zinit light zsh-users/zsh-autosuggestions
+zinit light zsh-users/zsh-completions
+
+# Aliases
+alias ls='exa --icons'
+alias cat='bat'
+alias grep='rg'
+alias find='fd'
+
+# Tools
+if command -v zoxide >/dev/null 2>&1; then
+  eval "$(zoxide init zsh)"
+fi
+if command -v starship >/dev/null 2>&1; then
+  eval "$(starship init zsh)"
+fi

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1,0 +1,37 @@
+# CLI Cheat Sheet
+
+Quick reference for some of the installed tools and aliases.
+
+## Navigation
+
+```bash
+z foo         # jump to directory containing 'foo' using zoxide
+ls            # mapped to exa --icons
+cat file      # uses bat for syntax highlighting
+rg pattern    # fast search for 'pattern'
+fd name       # find files or directories named 'name'
+```
+
+## tmux
+
+```bash
+tmux new -s session   # create new tmux session
+Ctrl-b d              # detach session
+Ctrl-b "              # split window horizontally
+Ctrl-b %              # split window vertically
+```
+
+## fzf
+
+```bash
+ctrl-r       # search shell history
+fzf          # fuzzy-find files
+```
+
+## entr
+
+```bash
+ls *.md | entr make   # run make whenever a markdown file changes
+```
+
+For more examples, check the official documentation linked in `command_reference.md`.

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -1,0 +1,21 @@
+# Command Reference
+
+This repository installs the following CLI tools:
+
+| Tool | Replaces | Description | Link |
+|------|----------|-------------|------|
+| `exa` | `ls` | Modern replacement for `ls` with colors and icons | https://github.com/ogham/exa |
+| `bat` | `cat` | Syntax highlighting and Git integration for `cat` | https://github.com/sharkdp/bat |
+| `ripgrep` (`rg`) | `grep` | Fast recursive search | https://github.com/BurntSushi/ripgrep |
+| `fd` | `find` | Simple, fast alternative to `find` | https://github.com/sharkdp/fd |
+| `fzf` | - | Fuzzy finder for the command line | https://github.com/junegunn/fzf |
+| `zoxide` | `cd` | Smarter `cd` command that learns | https://github.com/ajeetdsouza/zoxide |
+| `entr` | - | Run arbitrary commands when files change | https://github.com/eradman/entr |
+| `mc` | - | Midnight Commander, a text-mode file manager | https://midnight-commander.org/ |
+| `btop` | `top` | Resource monitor with a friendly UI | https://github.com/aristocratos/btop |
+| `tmux` | - | Terminal multiplexer | https://github.com/tmux/tmux |
+| `starship` | - | Cross-shell prompt | https://starship.rs |
+| `zinit` | - | Zsh plugin manager | https://github.com/zdharma-continuum/zinit |
+| `fisher` | - | Fish plugin manager | https://github.com/jorgebucaran/fisher |
+
+See the cheat sheet for common usage examples.

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,6 @@ create_symlinks() {
 }
 
 install_zsh() {
-  sudo apt-get install -y zsh
   if [ ! -f "${ZDOTDIR:-$HOME}/.zinit/bin/zinit.zsh" ]; then
     mkdir -p "${ZDOTDIR:-$HOME}/.zinit"
     git clone https://github.com/zdharma-continuum/zinit.git "${ZDOTDIR:-$HOME}/.zinit/bin"

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ install_zsh() {
 install_fish() {
   sudo apt-get install -y fish
   if ! command -v fisher >/dev/null 2>&1; then
-    curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher
+    curl -sL https://git.io/fisher | fish && fisher install jorgebucaran/fisher
   fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -e
+
+PACKAGES="btop tmux exa bat ripgrep fd-find fzf zoxide entr mc starship"
+
+install_packages() {
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y "$PACKAGES" zsh fish curl git
+  else
+    echo "Package manager not supported. Install packages manually: $PACKAGES" >&2
+  fi
+}
+
+create_symlinks() {
+  mkdir -p "$HOME/bin"
+  ln -sf "$(command -v exa)" "$HOME/bin/ls"
+  ln -sf "$(command -v batcat 2>/dev/null || command -v bat)" "$HOME/bin/cat"
+  ln -sf "$(command -v rg)" "$HOME/bin/grep"
+  ln -sf "$(command -v fdfind 2>/dev/null || command -v fd)" "$HOME/bin/find"
+  ln -sf "$(command -v fdfind 2>/dev/null || command -v fd)" "$HOME/bin/fd"
+}
+
+install_zsh() {
+  sudo apt-get install -y zsh
+  if [ ! -f "${ZDOTDIR:-$HOME}/.zinit/bin/zinit.zsh" ]; then
+    mkdir -p "${ZDOTDIR:-$HOME}/.zinit"
+    git clone https://github.com/zdharma-continuum/zinit.git "${ZDOTDIR:-$HOME}/.zinit/bin"
+  fi
+}
+
+install_fish() {
+  sudo apt-get install -y fish
+  if ! command -v fisher >/dev/null 2>&1; then
+    curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher
+  fi
+}
+
+install_starship() {
+  curl -fsSL https://starship.rs/install.sh | sh -s -- -y
+}
+
+main() {
+  install_packages
+  create_symlinks
+
+  read -rp "Install a shell? (default/zsh/fish) [default]: " shell_choice
+  case "$shell_choice" in
+    zsh|ZSH)
+      install_zsh
+      ;;
+    fish|FISH)
+      install_fish
+      ;;
+    *)
+      echo "Leaving default shell."
+      ;;
+  esac
+
+  read -rp "Install starship prompt? (y/N): " starship_choice
+  if [[ "$starship_choice" =~ ^[Yy]$ ]]; then
+    install_starship
+  fi
+
+  echo "Installation complete. Add $HOME/bin to your PATH for the aliases."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add `install.sh` to install common CLI tools, optional shells, starship prompt, and symlink replacements
- include Zsh and Fish configs with plugin managers and default aliases
- document installed tools and provide cheat sheets

## Testing
- `bash -n install.sh`
- `shellcheck install.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f695193ec83328a71ac380d4d2ce1